### PR TITLE
3 learningresourcetype

### DIFF
--- a/draft/examples/classification-example.xml
+++ b/draft/examples/classification-example.xml
@@ -10,20 +10,20 @@
         </purpose>
         <taxonpath>
             <source>
-                <langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme#</langstring>
+                <langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme</langstring>
             </source>
             <taxon>
-                <id>http://w3id.org/class/hochschulfaechersystematik/n4#</id>
+                <id>http://w3id.org/class/hochschulfaechersystematik/n4</id>
                 <entry>
                     <langstring>Mathematik, Naturwissenschaften</langstring>
                 </entry>
                 <taxon>
-                    <id>http://w3id.org/class/hochschulfaechersystematik/n37#</id>
+                    <id>http://w3id.org/class/hochschulfaechersystematik/n37</id>
                     <entry>
                         <langstring>Studienbereich Mathematik</langstring>
                     </entry>
                     <taxon>
-                        <id>http://w3id.org/class/hochschulfaechersystematik/n276#</id>
+                        <id>http://w3id.org/class/hochschulfaechersystematik/n276</id>
                         <entry>
                             <langstring>Wirtschaftsmathematik</langstring>
                         </entry>
@@ -33,15 +33,15 @@
         </taxonpath>
         <taxonpath>
             <source>
-                <langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme#</langstring>
+                <langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme</langstring>
             </source>
             <taxon>
-                <id>http://w3id.org/class/hochschulfaechersystematik/n3#</id>
+                <id>http://w3id.org/class/hochschulfaechersystematik/n3</id>
                 <entry>
                     <langstring>Rechts- Wirtschafts- und Sozialwissenschaften</langstring>
                 </entry>
                 <taxon>
-                    <id>http://w3id.org/class/hochschulfaechersystematik/n30#</id>
+                    <id>http://w3id.org/class/hochschulfaechersystematik/n30</id>
                     <entry>
                         <langstring>Wirtschaftswissenschaften</langstring>
                     </entry>

--- a/draft/examples/classification-example.xml
+++ b/draft/examples/classification-example.xml
@@ -10,7 +10,7 @@
         </purpose>
         <taxonpath>
             <source>
-                <langstring xml:lang="x-none">Hochschulfaecher</langstring>
+                <langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme#</langstring>
             </source>
             <taxon>
                 <id>http://w3id.org/class/hochschulfaechersystematik/n4#</id>
@@ -33,7 +33,7 @@
         </taxonpath>
         <taxonpath>
             <source>
-                <langstring xml:lang="x-none">Hochschulfaecher</langstring>
+                <langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme#</langstring>
             </source>
             <taxon>
                 <id>http://w3id.org/class/hochschulfaechersystematik/n3#</id>

--- a/draft/examples/classification-example.xml
+++ b/draft/examples/classification-example.xml
@@ -10,20 +10,20 @@
         </purpose>
         <taxonpath>
             <source>
-                <langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme</langstring>
+                <langstring xml:lang="x-none">https://w3id.org/kim/hochschulfaechersystematik/scheme</langstring>
             </source>
             <taxon>
-                <id>http://w3id.org/class/hochschulfaechersystematik/n4</id>
+                <id>http://w3id.org/kim/hochschulfaechersystematik/n4</id>
                 <entry>
                     <langstring>Mathematik, Naturwissenschaften</langstring>
                 </entry>
                 <taxon>
-                    <id>http://w3id.org/class/hochschulfaechersystematik/n37</id>
+                    <id>http://w3id.org/kim/hochschulfaechersystematik/n37</id>
                     <entry>
                         <langstring>Studienbereich Mathematik</langstring>
                     </entry>
                     <taxon>
-                        <id>http://w3id.org/class/hochschulfaechersystematik/n276</id>
+                        <id>http://w3id.org/kim/hochschulfaechersystematik/n276</id>
                         <entry>
                             <langstring>Wirtschaftsmathematik</langstring>
                         </entry>
@@ -33,15 +33,15 @@
         </taxonpath>
         <taxonpath>
             <source>
-                <langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme</langstring>
+                <langstring xml:lang="x-none">https://w3id.org/kim/hochschulfaechersystematik/scheme</langstring>
             </source>
             <taxon>
-                <id>http://w3id.org/class/hochschulfaechersystematik/n3</id>
+                <id>http://w3id.org/kim/hochschulfaechersystematik/n3</id>
                 <entry>
                     <langstring>Rechts- Wirtschafts- und Sozialwissenschaften</langstring>
                 </entry>
                 <taxon>
-                    <id>http://w3id.org/class/hochschulfaechersystematik/n30</id>
+                    <id>http://w3id.org/kim/hochschulfaechersystematik/n30</id>
                     <entry>
                         <langstring>Wirtschaftswissenschaften</langstring>
                     </entry>

--- a/draft/examples/educational-example.xml
+++ b/draft/examples/educational-example.xml
@@ -2,13 +2,12 @@
     <educational>
         <learningResourceType>
             <source>
-                <langstring xml:lang="x-none">
-                    Hochschulcampus Content Custom Model
-                </langstring>
-            </source>
-            <value>
-                <langstring xml:lang="x-none">video</langstring>
-            </value>
+                <langstring xml:lang="x-none">https://w3id.org/dini-ag-kim/hcrt/scheme</langstring>
+	    </source>
+	    <id>https://w3id.org/dini-ag-kim/hcrt/video</id>
+            <entry>
+                <langstring xml:lang="de">Video</langstring>
+            </entry>
         </learningResourceType>
         <description>
             <langstring>

--- a/draft/examples/educational-example.xml
+++ b/draft/examples/educational-example.xml
@@ -2,9 +2,9 @@
     <educational>
         <learningResourceType>
             <source>
-                <langstring xml:lang="x-none">https://w3id.org/dini-ag-kim/hcrt/scheme</langstring>
+                <langstring xml:lang="x-none">https://w3id.org/kim/hcrt/scheme</langstring>
 	    </source>
-	    <id>https://w3id.org/dini-ag-kim/hcrt/video</id>
+	    <id>https://w3id.org/kim/hcrt/video</id>
             <entry>
                 <langstring xml:lang="de">Video</langstring>
             </entry>

--- a/draft/examples/full-example-a.xml
+++ b/draft/examples/full-example-a.xml
@@ -9,6 +9,12 @@
 				<langstring>Introduction to Difference Equations</langstring>
 			</title>
 			<catalogentry>
+				<catalog>DOI</catalog>
+				<entry>
+					<langstring>10.1137/S0036144500378302</langstring>
+				</entry>
+			</catalogentry>
+			<catalogentry>
 				<catalog>HDL</catalog>
 				<entry>
 					<langstring>10900.3/OER_ZZxWvFJV</langstring>
@@ -164,13 +170,13 @@
 					</entry>
 				</taxon>
 				<taxon>
-					<id>http://w3id.org/class/hochschulfaechersystematik/n37</id>
+					<id>http://w3id.org/kim/hochschulfaechersystematik/n37</id>
 					<entry>
 						<langstring>Studienbereich Mathematik</langstring>
 					</entry>
 				</taxon>
 				<taxon>
-					<id>http://w3id.org/class/hochschulfaechersystematik/n276</id>
+					<id>http://w3id.org/kim/hochschulfaechersystematik/n276</id>
 					<entry>
 						<langstring>Wirtschaftsmathematik</langstring>
 					</entry>
@@ -187,7 +193,7 @@
 					</entry>
 				</taxon>
 				<taxon>
-					<id>http://w3id.org/class/hochschulfaechersystematik/n30</id>
+					<id>http://w3id.org/kim/hochschulfaechersystematik/n30</id>
 					<entry>
 						<langstring>Wirtschaftswissenschaften</langstring>
 					</entry>

--- a/draft/examples/full-example-a.xml
+++ b/draft/examples/full-example-a.xml
@@ -112,23 +112,21 @@
 		<educational>
 			<learningResourceType>
 				<source>
-					<langstring xml:lang="x-none">
-						Hochschulcampus Content Custom Model
-					</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/dini-ag-kim/hcrt/scheme</langstring>
 				</source>
-				<value>
-					<langstring xml:lang="x-none">video</langstring>
-				</value>
+				<id>https://w3id.org/dini-ag-kim/hcrt/video</id>
+				<entry>
+					<langstring xml:lang="de">Video</langstring>
+				</entry>
 			</learningResourceType>
 			<learningResourceType>
 				<source>
-					<langstring xml:lang="x-none">
-						Hochschulcampus Content Custom Model
-					</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/dini-ag-kim/hcrt/scheme</langstring>
 				</source>
-				<value>
-					<langstring xml:lang="x-none">course</langstring>
-				</value>
+				<id>https://w3id.org/dini-ag-kim/hcrt/course</id>
+				<entry>
+					<langstring xml:lang="de">Lernkurs</langstring>
+				</entry>
 			</learningResourceType>
 		</educational>
 		<rights>
@@ -157,7 +155,7 @@
 			</purpose>
 			<taxonpath>
 				<source>
-					<langstring xml:lang="x-none">Hochschulfaecher</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme#</langstring>
 				</source>
 				<taxon>
 					<id>http://w3id.org/class/hochschulfaechersystematik/n4#</id>
@@ -180,7 +178,7 @@
 			</taxonpath>
 			<taxonpath>
 				<source>
-					<langstring xml:lang="x-none">Hochschulfaecher</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme#</langstring>
 				</source>
 				<taxon>
 					<id>http://w3id.org/class/hochschulfaechersystematik/n3#</id>

--- a/draft/examples/full-example-a.xml
+++ b/draft/examples/full-example-a.xml
@@ -155,20 +155,20 @@
 			</purpose>
 			<taxonpath>
 				<source>
-					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme#</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme</langstring>
 				</source>
 				<taxon>
-					<id>http://w3id.org/class/hochschulfaechersystematik/n4#</id>
+					<id>http://w3id.org/class/hochschulfaechersystematik/n4</id>
 					<entry>
 						<langstring>Mathematik, Naturwissenschaften</langstring>
 					</entry>
 					<taxon>
-						<id>http://w3id.org/class/hochschulfaechersystematik/n37#</id>
+						<id>http://w3id.org/class/hochschulfaechersystematik/n37</id>
 						<entry>
 							<langstring>Studienbereich Mathematik</langstring>
 						</entry>
 						<taxon>
-							<id>http://w3id.org/class/hochschulfaechersystematik/n276#</id>
+							<id>http://w3id.org/class/hochschulfaechersystematik/n276</id>
 							<entry>
 								<langstring>Wirtschaftsmathematik</langstring>
 							</entry>
@@ -178,15 +178,15 @@
 			</taxonpath>
 			<taxonpath>
 				<source>
-					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme#</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme</langstring>
 				</source>
 				<taxon>
-					<id>http://w3id.org/class/hochschulfaechersystematik/n3#</id>
+					<id>http://w3id.org/class/hochschulfaechersystematik/n3</id>
 					<entry>
 						<langstring> Rechts-, Wirtschafts- und Sozialwissenschaften</langstring>
 					</entry>
 					<taxon>
-						<id>http://w3id.org/class/hochschulfaechersystematik/n30#</id>
+						<id>http://w3id.org/class/hochschulfaechersystematik/n30</id>
 						<entry>
 							<langstring>Wirtschaftswissenschaften</langstring>
 						</entry>

--- a/draft/examples/full-example-a.xml
+++ b/draft/examples/full-example-a.xml
@@ -42,8 +42,8 @@
 					<vcard>
 						BEGIN:VCARD
 						VERSION:3.0
-						N:Meier;Thomas
-						FN:Thomas Meier
+						N:Dimpfl;Thomas
+						FN:Thomas Dimpfl
 						URL:https://orcid.org/0000-0003-3415-7412
 						END:VCARD
 					</vcard>
@@ -64,8 +64,8 @@
 					<vcard>
 						BEGIN:VCARD
 						VERSION:3.0
-						N:Meier;Thomas
-						FN:Thomas Meier
+						N:Dimpfl;Thomas
+						FN:Thomas Dimpfl
 						URL:https://orcid.org/0000-0003-3415-7412
 						END:VCARD
 					</vcard>
@@ -112,18 +112,18 @@
 		<educational>
 			<learningResourceType>
 				<source>
-					<langstring xml:lang="x-none">https://w3id.org/dini-ag-kim/hcrt/scheme</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/kim/hcrt/scheme</langstring>
 				</source>
-				<id>https://w3id.org/dini-ag-kim/hcrt/video</id>
+				<id>https://w3id.org/kim/hcrt/video</id>
 				<entry>
 					<langstring xml:lang="de">Video</langstring>
 				</entry>
 			</learningResourceType>
 			<learningResourceType>
 				<source>
-					<langstring xml:lang="x-none">https://w3id.org/dini-ag-kim/hcrt/scheme</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/kim/hcrt/scheme</langstring>
 				</source>
-				<id>https://w3id.org/dini-ag-kim/hcrt/course</id>
+				<id>https://w3id.org/kim/hcrt/course</id>
 				<entry>
 					<langstring xml:lang="de">Lernkurs</langstring>
 				</entry>
@@ -155,20 +155,20 @@
 			</purpose>
 			<taxonpath>
 				<source>
-					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/kim/hochschulfaechersystematik/scheme</langstring>
 				</source>
 				<taxon>
-					<id>http://w3id.org/class/hochschulfaechersystematik/n4</id>
+					<id>http://w3id.org/kim/hochschulfaechersystematik/n4</id>
 					<entry>
 						<langstring>Mathematik, Naturwissenschaften</langstring>
 					</entry>
 					<taxon>
-						<id>http://w3id.org/class/hochschulfaechersystematik/n37</id>
+						<id>http://w3id.org/kim/hochschulfaechersystematik/n37</id>
 						<entry>
 							<langstring>Studienbereich Mathematik</langstring>
 						</entry>
 						<taxon>
-							<id>http://w3id.org/class/hochschulfaechersystematik/n276</id>
+							<id>http://w3id.org/kim/hochschulfaechersystematik/n276</id>
 							<entry>
 								<langstring>Wirtschaftsmathematik</langstring>
 							</entry>
@@ -178,15 +178,15 @@
 			</taxonpath>
 			<taxonpath>
 				<source>
-					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/kim/hochschulfaechersystematik/scheme</langstring>
 				</source>
 				<taxon>
-					<id>http://w3id.org/class/hochschulfaechersystematik/n3</id>
+					<id>http://w3id.org/kim/hochschulfaechersystematik/n3</id>
 					<entry>
 						<langstring> Rechts-, Wirtschafts- und Sozialwissenschaften</langstring>
 					</entry>
 					<taxon>
-						<id>http://w3id.org/class/hochschulfaechersystematik/n30</id>
+						<id>http://w3id.org/kim/hochschulfaechersystematik/n30</id>
 						<entry>
 							<langstring>Wirtschaftswissenschaften</langstring>
 						</entry>

--- a/draft/examples/full-example-b.xml
+++ b/draft/examples/full-example-b.xml
@@ -205,20 +205,20 @@
 			</purpose>
 			<taxonpath>
 				<source>
-					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme#</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme</langstring>
 				</source>
 				<taxon>
-					<id>http://w3id.org/class/hochschulfaechersystematik/n3#</id>
+					<id>http://w3id.org/class/hochschulfaechersystematik/n3</id>
 					<entry>
 						<langstring> Rechts-, Wirtschafts- und Sozialwissenschaften</langstring>
 					</entry>
 					<taxon>
-						<id>http://w3id.org/class/hochschulfaechersystematik/n33#</id>
+						<id>http://w3id.org/class/hochschulfaechersystematik/n33</id>
 						<entry>
 							<langstring>Erziehungswissenschaften</langstring>
 						</entry>
 						<taxon>
-							<id>http://w3id.org/class/hochschulfaechersystematik/n052#</id>
+							<id>http://w3id.org/class/hochschulfaechersystematik/n052</id>
 							<entry>
 								<langstring>Erziehungswissenschaft (Pädagogik)</langstring>
 							</entry>

--- a/draft/examples/full-example-b.xml
+++ b/draft/examples/full-example-b.xml
@@ -164,11 +164,14 @@
 		<educational>
 			<learningResourceType>
 				<source>
-					<langstring xml:lang="x-none">Hochschulcampus Content Custom Model</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/dini-ag-kim/hcrt/scheme</langstring>
 				</source>
-				<value>
-					<langstring xml:lang="x-none">lesson_plan</langstring>
-				</value>
+				<id>https://w3id.org/dini-ag-kim/hcrt/lesson_plan</id>
+				<entry>
+					<langstring xml:lang="de">
+						Unterrichtsplanung
+					</langstring>
+				</entry>
 			</learningResourceType>
 			<description>
 				<langstring>
@@ -202,7 +205,7 @@
 			</purpose>
 			<taxonpath>
 				<source>
-					<langstring xml:lang="x-none">Hochschulfaecher</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme#</langstring>
 				</source>
 				<taxon>
 					<id>http://w3id.org/class/hochschulfaechersystematik/n3#</id>

--- a/draft/examples/full-example-b.xml
+++ b/draft/examples/full-example-b.xml
@@ -212,13 +212,13 @@
 					</entry>
 				</taxon>
 				<taxon>
-					<id>http://w3id.org/class/hochschulfaechersystematik/n33</id>
+					<id>http://w3id.org/kim/hochschulfaechersystematik/n33</id>
 					<entry>
 						<langstring>Erziehungswissenschaften</langstring>
 					</entry>
 				</taxon>
 				<taxon>
-					<id>http://w3id.org/class/hochschulfaechersystematik/n052</id>
+					<id>http://w3id.org/kim/hochschulfaechersystematik/n052</id>
 					<entry>
 						<langstring>Erziehungswissenschaft (Pädagogik)</langstring>
 					</entry>

--- a/draft/examples/full-example-b.xml
+++ b/draft/examples/full-example-b.xml
@@ -164,13 +164,11 @@
 		<educational>
 			<learningResourceType>
 				<source>
-					<langstring xml:lang="x-none">https://w3id.org/dini-ag-kim/hcrt/scheme</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/kim/hcrt/scheme</langstring>
 				</source>
-				<id>https://w3id.org/dini-ag-kim/hcrt/lesson_plan</id>
+				<id>https://w3id.org/kim/hcrt/lesson_plan</id>
 				<entry>
-					<langstring xml:lang="de">
-						Unterrichtsplanung
-					</langstring>
+					<langstring xml:lang="de">Unterrichtsplanung</langstring>
 				</entry>
 			</learningResourceType>
 			<description>
@@ -205,20 +203,20 @@
 			</purpose>
 			<taxonpath>
 				<source>
-					<langstring xml:lang="x-none">https://w3id.org/class/hochschulfaechersystematik/scheme</langstring>
+					<langstring xml:lang="x-none">https://w3id.org/kim/hochschulfaechersystematik/scheme</langstring>
 				</source>
 				<taxon>
-					<id>http://w3id.org/class/hochschulfaechersystematik/n3</id>
+					<id>http://w3id.org/kim/hochschulfaechersystematik/n3</id>
 					<entry>
 						<langstring> Rechts-, Wirtschafts- und Sozialwissenschaften</langstring>
 					</entry>
 					<taxon>
-						<id>http://w3id.org/class/hochschulfaechersystematik/n33</id>
+						<id>http://w3id.org/kim/hochschulfaechersystematik/n33</id>
 						<entry>
 							<langstring>Erziehungswissenschaften</langstring>
 						</entry>
 						<taxon>
-							<id>http://w3id.org/class/hochschulfaechersystematik/n052</id>
+							<id>http://w3id.org/kim/hochschulfaechersystematik/n052</id>
 							<entry>
 								<langstring>Erziehungswissenschaft (Pädagogik)</langstring>
 							</entry>

--- a/draft/index.html
+++ b/draft/index.html
@@ -114,7 +114,7 @@
                 },
                 "SKOS-HS": {
                     title: "Destatis-Systematik der Fächergruppen, Studienbereiche und Studienfächer",
-                    href: "https://w3id.org/class/hochschulfaechersystematik/scheme#",
+                    href: "https://w3id.org/class/hochschulfaechersystematik/scheme",
                     publisher: "Statistisches Bundesamt der Bundesrepublik Deutschland"
                 },
                 "SKOS-LRT": {
@@ -968,7 +968,7 @@ Das Element beschreibt den Pfad der Taxonomie in der konkreten Klassifizierung.
     <dt>Elemente:</dt>
     <dd>
         <a>&lt;source></a> - Je nach verwendeter Klassifizierung wird es auf den
-        Wert `https://w3id.org/class/hochschulfaechersystematik/scheme#` oder `DDC` gesetzt.
+        Wert `https://w3id.org/class/hochschulfaechersystematik/scheme` oder `DDC` gesetzt.
 
         <a>&lt;taxon></a>
     </dd>
@@ -1299,7 +1299,7 @@ kontrolliertes Vokabular zurückgegriffen.
 
 Das Element benennt die Quelle des Vokabulars. Es ist abhängig vom Kontext der
 Verwendung auf `LOMv1.0`, `https://w3id.org/dini-ag-kim/hcrt/scheme`,
-`https://w3id.org/class/hochschulfaechersystematik/scheme#` oder `DDC` zu
+`https://w3id.org/class/hochschulfaechersystematik/scheme` oder `DDC` zu
 setzen. Die zulässigen Werte sind jeweils beim übergeordneten Element angegeben.
 
 <dl>

--- a/draft/index.html
+++ b/draft/index.html
@@ -1144,7 +1144,7 @@ Das Element bezeichnet den konkreten Eintrag in einer Taxonomie oder einem Katal
 
 <dl>
     <dt>Mehrwertigkeit:</dt>
-    <dd>Es MUSS genau 1 Mal innerhalb übergeordneten Elements vorkommen.</dd>
+    <dd>Es MUSS genau 1 Mal innerhalb des übergeordneten Elements vorkommen.</dd>
     <dt>Attribute:</dt>
     <dd>keine</dd>
     <dt>Elemente:</dt>

--- a/draft/index.html
+++ b/draft/index.html
@@ -86,9 +86,9 @@
                     publisher: "IEEE"
                 },
                 "LOMv1.2": {
-                    title: "IMS Learning Resource Meta-Data XML Binding Specification",
-                    href: "https://www.imsglobal.org/metadata/imsmdv1p2p1/imsmd_bindv1p2p1.html",
-                    status: "Final Specification 1.2.1",
+                    title: "IMS Learning Resource Meta-data Specification",
+                    href: "https://www.imsglobal.org/metadata/index.html",
+                    status: "Maintenance Release 1.2.4",
                     publisher: "IMS Global Learning Consortium, Inc."
                 },
                 "MIME": {
@@ -116,6 +116,11 @@
                     title: "Destatis-Systematik der Fächergruppen, Studienbereiche und Studienfächer",
                     href: "https://w3id.org/class/hochschulfaechersystematik/scheme#",
                     publisher: "Statistisches Bundesamt der Bundesrepublik Deutschland"
+                },
+                "SKOS-LRT": {
+                    title: "Hochschulcampus Ressourcentypen",
+                    href: "https://w3id.org/dini-ag-kim/hcrt/scheme",
+                    publisher: "OER-Repo AG der Länder"
                 },
                 "Wikidata": {
                     title: "Wikidata",
@@ -167,7 +172,7 @@ Schemata schwer zu lesen sind, gibt es diese Dokumentation.
 
 Kenntnisse über grundlegende XML–Eigenschaften werden vorausgesetzt und
 nicht erläutert. Vielfältige Informationen dazu gibt es im WWW oder
-auch in der Einleitung der [[?LOMv1.2]]-Spezifikation.
+auch in der [[?LOMv1.2]]-Spezifikation.
 
 Die weitere Entwicklung und Pflege des Standards wird in einem
 [GitHub-Repositorium](https://github.com/dini-ag-kim/hs-oer-lom-profil/)
@@ -591,7 +596,7 @@ Metadaten beteiligt waren.
         geeignete Stelle, um das Veröffentlichungsdatum im Repositorium als
         <a>&lt;date></a> anzugeben.
 
-        Die erlaubten Angaben aus [[!LOMv1.0]] für <a>&lt;role></a> sind:
+        Die erlaubten Werte für <a>&lt;role></a> sind:
 
         - `Creator`
 
@@ -794,60 +799,17 @@ Das Element benennt die Art des Lernobjekts.
     <dd>keine</dd>
     <dt>Elemente:</dt>
     <dd>
-        <a>&lt;source></a> mit dem Wert `Hochschulcampus Content Custom Model`<br>
-        <a>&lt;value></a>
+        <a>&lt;source></a> mit dem Wert `https://w3id.org/dini-ag-kim/hcrt/scheme`<br>
+        <a>&lt;id></a><br>
+        <a>&lt;entry></a> - Es benennt die konkrete Art des Objekts
+        mittels eines Labels. Da die <a>&lt;id></a>
+        das entscheidende Klassifikationsmerkmal ist, hat dieses Element nur
+        beschreibenden Charakter.<br>
 
-        Für das `Hochschulcampus Content Custom Model` sind die erlaubten Werte (mit
-        erläuternden Bedeutungen in deutsch), die bei Bedarf und nach Abstimmung
-        erweitert werden können:
-
-        - `application` - Anwendung, Software
-
-        - `assessment` - Lernkontrolle, (Selbst-)Test
-
-        - `audio` - Tonaufnahme
-
-        - `case_study` - Fallstudie
-
-        - `course` - Lernkurs
-
-        - `data` - (Roh-, Beispiel-) Daten
-
-        - `diagram` - Diagramm, Grafik
-
-        - `drill_and_practice` - Übung
-
-        - `educational_game` - Lernspiel
-
-        - `experiment` - Experiment
-
-        - `image` - Abbildung, Foto, Bild
-
-        - `index` - Glossar, Nachschlagewerk, Wiki, Lexikon
-
-        - `lesson_plan` - Unterrichtsplanung, Unterrichtsgestaltung
-
-        - `map` - Karte
-
-        - `portal` - (Web-, Wissens-) Portal
-
-        - `questionnaire` - Fragebogen, Rechercheauftrag
-
-        - `script` - Skript
-
-        - `simulation` - Simulation
-
-        - `slide` - Präsentation, Folien
-
-        - `text` - Artikel, Aufstatz, Text, Abhandlung 
-
-        - `video` - Video
-
-        - `web_page` - Webseite
-
-        - `worksheet` - Arbeitsblatt, Arbeitsmaterial
-
-        - `other` - sonstiges
+        Für die Arten des Lernobjekts wurden „Hochschulcampus Ressourcentypen“
+        in Anlehnung an LOM spezifiziert, die in [[!SKOS-LRT]] repräsentiert
+        sind. Die angegebene URL in <a>&lt;source></a> stellt den persistenten
+        Link zur Repräsentation dar.
     </dd>
 </dl>
 
@@ -981,28 +943,9 @@ Das Element charakterisiert die Art der Klassifizierung.
     <dt>Elemente:</dt>
     <dd>
         <a>&lt;source></a> mit dem Wert `LOMv1.0`<br>
-        <a>&lt;value></a> - Es benennt die konkrete Art der Klassifizierung.
-
-        Die von [[!LOMv1.0]] erlaubten Werte sind:
-
-        - `Accessibility Restrictions`
-
-        - `Discipline`
-
-        - `Educational Level`
-
-        - `Educational Objective`
-
-        - `Idea`
-
-        - `Prerequisite`
-
-        - `Security Level`
-
-        - `Skill Level`
-
-        Für den Zweck der Klassifizierung nach Fachgebieten ist nur `Discipline`
-        interessant und im XML Schema auch forciert.
+        <a>&lt;value></a> - Es benennt die konkrete Art der Klassifizierung.<br>
+        Da die Klassifizierung nur nach Fachgebieten vorgesehen ist, ist nur der
+        Wert `Discipline` erlaubt und wird im XML Schema auch forciert.
     </dd>
 </dl>
 
@@ -1025,7 +968,7 @@ Das Element beschreibt den Pfad der Taxonomie in der konkreten Klassifizierung.
     <dt>Elemente:</dt>
     <dd>
         <a>&lt;source></a> - Je nach verwendeter Klassifizierung wird es auf den
-        Wert `Hochschulfaecher` oder `DDC` gesetzt.
+        Wert `https://w3id.org/class/hochschulfaechersystematik/scheme#` oder `DDC` gesetzt.
 
         <a>&lt;taxon></a>
     </dd>
@@ -1059,45 +1002,6 @@ damit einen Taxonomiepfad, d. h. eine hierarchisch sich verfeinernde Klassifikat
         <a>&lt;taxon></a>
     </dd>
 </dl>
-
-<section data-dfn-for="id">
-
-## Das Element <dfn><code>&lt;id></code></dfn>
-
-Das Element benennt die konkrete Klassifikation des Objekts im Rahmen der bezeichneten
-Taxonomie mittels einer ID, die den Anspruch auf dauerhafte Gültigkeit erhebt.
-
-**Für Hochschulfächer:**
-
-Es wird der von der [W3C Permanent Identifier Community Group](https://w3id.org/)
-eingerichtete Service für permanente Identifier im WWW genutzt. Damit bekommt jedes
-Fach eine URL als ID, die in [[!SKOS-HS]] nachgeschlagen werden können.
-
-Die ID-Nr. besteht dabei aus einem Kleinbuchstaben und einer oder mehreren Ziffern.
-Die URL löst dabei zu den im [[!SKOS-HS]] hinterlegten Eintrag zum Fachgebiet nebst
-Beschreibung auf.
-
-**Für DDC:**
-
-Aus der [[!DDC]] ergeben sich eindeutige Zahlen. Es ist wie in der DDC Summary
-beschrieben mit 0 auf 3 Ziffern aufzufüllen. 
-
-<p class="note">Die XML Schema Definition kann validieren, dass nur gültige URLs
-oder DDC-Codes verwendet werden und ebenfalls dass im obigen Element <a>&lt;source></a>
-nur einer der beiden spezifizierten Werte angegeben wird. Aufgrund von sprachlichen
-Limitierungen können jedoch bei der Validierung keine falschen Angaben über Kreuz
-aufgedeckt werden, also z. B. `Hochschulfaecher` mit einem DDC-Zifferncode.</p>
-
-<dl>
-    <dt>Mehrwertigkeit:</dt>
-    <dd>Es MUSS genau 1 Mal innerhalb des Elements <a>&lt;taxon></a> vorkommen.</dd>
-    <dt>Attribute:</dt>
-    <dd>keine</dd>
-    <dt>Elemente:</dt>
-    <dd>keine</dd>
-</dl>
-
-</section>
 
 </section>
 
@@ -1182,6 +1086,53 @@ eine Uhrzeit und eine Zeitzone entsprechend [[!ISO8601]].
 <pre class="example" data-include="examples/datetime-example.xml" data-include-format="text"></pre>
 
 [Link zum Beispiel](examples/datetime-example.xml)
+
+</section>
+
+<section data-dfn-for="id">
+
+## Das Element <dfn><code>&lt;id></code></dfn>
+
+Das Element benennt die konkrete Klassifikation des Objekts im Rahmen der bezeichneten
+Taxonomie mittels einer ID, die den Anspruch auf dauerhafte Gültigkeit erhebt.
+
+**Für Hochschulcampus Ressourcentypen:**
+
+Es wird der von der [W3C Permanent Identifier Community Group](https://w3id.org/)
+eingerichtete Service für permanente Identifier im WWW genutzt. Damit bekommt jeder
+Ressourcentyp eine URL als ID, die in [[!SKOS-LRT]] nachgeschlagen werden kann.
+Die URL löst dabei zu den im [[!SKOS-LRT]] hinterlegten Eintrag zu diesem
+Hochschulcampus Ressourcentyp nebst einer eventuellen Erläuterung auf.
+
+**Für Hochschulfächer:**
+
+Es wird der von der [W3C Permanent Identifier Community Group](https://w3id.org/)
+eingerichtete Service für permanente Identifier im WWW genutzt. Damit bekommt jedes
+Fach eine URL als ID, die in [[!SKOS-HS]] nachgeschlagen werden kann.
+
+Die ID-Nr. besteht dabei aus einem Kleinbuchstaben und einer oder mehreren Ziffern.
+Die URL löst dabei zu den im [[!SKOS-HS]] hinterlegten Eintrag zum Fachgebiet nebst
+Beschreibung auf.
+
+**Für DDC:**
+
+Aus der [[!DDC]] ergeben sich eindeutige Zahlen. Es ist wie in der DDC Summary
+beschrieben mit 0 auf 3 Ziffern aufzufüllen. 
+
+<p class="note">Die XML Schema Definition kann validieren, dass nur gültige URLs
+oder DDC-Codes verwendet werden und ebenfalls dass im obigen Element <a>&lt;source></a>
+nur einer der beiden spezifizierten Werte angegeben wird. Aufgrund von sprachlichen
+Limitierungen können jedoch bei der Validierung keine falschen Angaben über Kreuz
+aufgedeckt werden, also z. B. Hochschulfächer mit einem DDC-Zifferncode.</p>
+
+<dl>
+    <dt>Mehrwertigkeit:</dt>
+    <dd>Es MUSS genau 1 Mal innerhalb des übergeordnetenElements vorkommen.</dd>
+    <dt>Attribute:</dt>
+    <dd>keine</dd>
+    <dt>Elemente:</dt>
+    <dd>keine</dd>
+</dl>
 
 </section>
 
@@ -1347,9 +1298,9 @@ kontrolliertes Vokabular zurückgegriffen.
 ## Das Element <dfn><code>&lt;source></code></dfn>
 
 Das Element benennt die Quelle des Vokabulars. Es ist abhängig vom Kontext der
-Verwendung auf `LOMv1.0`, `Hochschulcampus Content Custom Model`, `Hochschulfaecher`
-oder `DDC` zu setzen. Die zulässigen Werte sind jeweils beim übergeordneten Element
-angegeben.
+Verwendung auf `LOMv1.0`, `https://w3id.org/dini-ag-kim/hcrt/scheme`,
+`https://w3id.org/class/hochschulfaechersystematik/scheme#` oder `DDC` zu
+setzen. Die zulässigen Werte sind jeweils beim übergeordneten Element angegeben.
 
 <dl>
     <dt>Mehrwertigkeit:</dt>

--- a/draft/index.html
+++ b/draft/index.html
@@ -920,7 +920,7 @@ der [*Fächersystematik für Studierende an Hochschulen* des Statistischen Bunde
 Dazu gibt es eine Repräsentation der Fachgebiete und der Hierarchie in [[!SKOS-HS]].
 
 <p class="note">Zusätzlich kann eine Klassifikation nach der <em>Dewey Decimal
-Classification</em> [[?DDC]] erfolgen. Es sollten nicht mehr als 3 Hierarchiebenen
+Classification</em> [[?DDC]] erfolgen. Es dürfen nicht mehr als 3 Hierarchiebenen
 verwendet werden. Im Folgenden wird bei den einzelnen Unterelementen auf Eigenheiten
 bei der Verwendung der [[?DDC]] hingewiesen.</p>
 
@@ -1104,53 +1104,6 @@ eine Uhrzeit und eine Zeitzone entsprechend [[!ISO8601]].
 
 </section>
 
-<section data-dfn-for="id">
-
-## Das Element <dfn><code>&lt;id></code></dfn>
-
-Das Element benennt die konkrete Klassifikation des Objekts im Rahmen der bezeichneten
-Taxonomie mittels einer ID, die den Anspruch auf dauerhafte Gültigkeit erhebt.
-
-**Für Hochschulcampus Ressourcentypen:**
-
-Es wird der von der [W3C Permanent Identifier Community Group](https://w3id.org/)
-eingerichtete Service für permanente Identifier im WWW genutzt. Damit bekommt jeder
-Ressourcentyp eine URL als ID, die in [[!SKOS-LRT]] nachgeschlagen werden kann.
-Die URL löst dabei zu den im [[!SKOS-LRT]] hinterlegten Eintrag zu diesem
-Hochschulcampus Ressourcentyp nebst einer eventuellen Erläuterung auf.
-
-**Für Hochschulfächer:**
-
-Es wird der von der [W3C Permanent Identifier Community Group](https://w3id.org/)
-eingerichtete Service für permanente Identifier im WWW genutzt. Damit bekommt jedes
-Fach eine URL als ID, die in [[!SKOS-HS]] nachgeschlagen werden kann.
-
-Die ID-Nr. besteht dabei aus einem Kleinbuchstaben und einer oder mehreren Ziffern.
-Die URL löst dabei zu den im [[!SKOS-HS]] hinterlegten Eintrag zum Fachgebiet nebst
-Beschreibung auf.
-
-**Für DDC:**
-
-Aus der [[!DDC]] ergeben sich eindeutige Zahlen. Es ist wie in der DDC Summary
-beschrieben mit 0 auf 3 Ziffern aufzufüllen. 
-
-<p class="note">Die XML Schema Definition kann validieren, dass nur gültige URLs
-oder DDC-Codes verwendet werden und ebenfalls dass im obigen Element <a>&lt;source></a>
-nur einer der beiden spezifizierten Werte angegeben wird. Aufgrund von sprachlichen
-Limitierungen können jedoch bei der Validierung keine falschen Angaben über Kreuz
-aufgedeckt werden, also z. B. Hochschulfächer mit einem DDC-Zifferncode.</p>
-
-<dl>
-    <dt>Mehrwertigkeit:</dt>
-    <dd>Es MUSS genau 1 Mal innerhalb des übergeordnetenElements vorkommen.</dd>
-    <dt>Attribute:</dt>
-    <dd>keine</dd>
-    <dt>Elemente:</dt>
-    <dd>keine</dd>
-</dl>
-
-</section>
-
 <section data-dfn-for="entry">
 
 ## Das Element <dfn><code>&lt;entry></code></dfn>
@@ -1317,7 +1270,7 @@ kontrolliertes Vokabular zurückgegriffen.
 ## Das Element <dfn><code>&lt;source></code></dfn>
 
 Das Element benennt die Quelle des Vokabulars. Es ist abhängig vom Kontext der
-Verwendung auf `LOMv1.0`, `https://w3id.org/dini-ag-kim/kim/scheme`,
+Verwendung auf `LOMv1.0`, `https://w3id.org/kim/hcrt/scheme`,
 `https://w3id.org/kim/hochschulfaechersystematik/scheme` oder `DDC` zu
 setzen. Die zulässigen Werte sind jeweils beim übergeordneten Element angegeben.
 
@@ -1328,6 +1281,51 @@ setzen. Die zulässigen Werte sind jeweils beim übergeordneten Element angegebe
     <dd>keine</dd>
     <dt>Elemente:</dt>
     <dd><a>&lt;langstring></a> mit dem Attribut `xml:lang="x-none"`</dd>
+</dl>
+
+</section>
+
+<section data-dfn-for="id">
+
+## Das Element <dfn><code>&lt;id></code></dfn>
+
+Das Element enthält einen URI, mittels dessen die konkrete Kategorie eindeutig
+identifiziert wird, der das Objekts im Rahmen der bezeichneten
+Taxonomie zugeordnet wird.
+
+**Für Hochschulcampus Ressourcentypen:**
+
+Es werden [permanente Identifier im WWW](https://w3id.org/) genutzt. Damit
+bekommt jeder Ressourcentyp eine URL als ID, die in [[!SKOS-LRT]] nachgeschlagen werden kann.
+Die URL löst dabei zu den im [[!SKOS-LRT]] hinterlegten Eintrag zu diesem
+Hochschulcampus Ressourcentyp nebst einer eventuellen Erläuterung auf.
+
+**Für Hochschulfächer:**
+
+Es werden [permanente Identifier im WWW](https://w3id.org/) genutzt. Damit bekommt jedes
+Fach eine URL als ID, die in [[!SKOS-HS]] nachgeschlagen werden kann.
+Die URL löst dabei zu den im [[!SKOS-HS]] hinterlegten Eintrag zum Fachgebiet nebst
+Beschreibung auf.
+
+**Für DDC:**
+
+Aus der [[!DDC]] ergeben sich eindeutige Zahlen. Es ist wie in der DDC Summary
+beschrieben mit 0 auf 3 Ziffern aufzufüllen. Die Klassifikation wird auf
+maximal die 3 Hauptebenen beschränkt, feinere Unterteilungen werden nicht unterstützt.
+
+<p class="note">Die XML Schema Definition kann validieren, dass nur gültige URLs
+oder DDC-Codes verwendet werden und ebenfalls dass im obigen Element <a>&lt;source></a>
+nur einer der beiden spezifizierten Werte angegeben wird. Aufgrund von sprachlichen
+Limitierungen können jedoch bei der Validierung keine falschen Angaben über Kreuz
+aufgedeckt werden, also z. B. Hochschulfächer mit einem DDC-Zifferncode.</p>
+
+<dl>
+    <dt>Mehrwertigkeit:</dt>
+    <dd>Es MUSS genau 1 Mal innerhalb des übergeordnetenElements vorkommen.</dd>
+    <dt>Attribute:</dt>
+    <dd>keine</dd>
+    <dt>Elemente:</dt>
+    <dd>keine</dd>
 </dl>
 
 </section>
@@ -1358,16 +1356,14 @@ kontrollierten Vokabular.
 
 ## Beispiele
 
-Zur Illustration sind zwei Beispiele für Metadatenbeschreibungen von
-Lernobjekten in XML hier zu finden.
+Zur Illustration werden zwei Beispiele für Metadatenbeschreibungen von
+Lernobjekten entsprechend dieser Spezifikation vorgestellt.
 
 <section id="example-1">
 
 ## Beispiel 1
 
-Das ist ein Beispiel für eine OER aus dem ZOERR, deren Metadaten in
-LOM beschrieben werden. Für Vergleichszwecke die Ansicht der OER im
-ZOERR: http://hdl.handle.net/10900.3/OER_ZZxWvFJV
+Das ist ein Beispiel für eine OER aus dem Bereich Mathematik.
 
 <pre class="example" data-include="examples/full-example-a.xml" data-include-format="text"></pre>
 
@@ -1379,9 +1375,7 @@ ZOERR: http://hdl.handle.net/10900.3/OER_ZZxWvFJV
 
 ## Beispiel 2
 
-Das ist ein weiteres Beispiel für eine OER aus dem ZOERR, deren Metadaten in
-LOM beschrieben werden. Für Vergleichszwecke die Ansicht der OER im
-ZOERR: http://hdl.handle.net/10900.3/OER_qiYOaTBN
+Das ist ein weiteres Beispiel für eine OER mit einer DDC-Klassifizierung.
 
 <pre class="example" data-include="examples/full-example-b.xml" data-include-format="text"></pre>
 

--- a/draft/index.html
+++ b/draft/index.html
@@ -114,12 +114,12 @@
                 },
                 "SKOS-HS": {
                     title: "Destatis-Systematik der Fächergruppen, Studienbereiche und Studienfächer",
-                    href: "https://w3id.org/class/hochschulfaechersystematik/scheme",
+                    href: "https://w3id.org/kim/hochschulfaechersystematik/scheme",
                     publisher: "Statistisches Bundesamt der Bundesrepublik Deutschland"
                 },
                 "SKOS-LRT": {
                     title: "Hochschulcampus Ressourcentypen",
-                    href: "https://w3id.org/dini-ag-kim/hcrt/scheme",
+                    href: "https://w3id.org/kim/hcrt/scheme",
                     publisher: "OER-Repo AG der Länder"
                 },
                 "Wikidata": {
@@ -174,9 +174,9 @@ Kenntnisse über grundlegende XML–Eigenschaften werden vorausgesetzt und
 nicht erläutert. Vielfältige Informationen dazu gibt es im WWW oder
 auch in der [[?LOMv1.2]]-Spezifikation.
 
-Die weitere Entwicklung und Pflege des Standards wird in einem
-[GitHub-Repositorium](https://github.com/dini-ag-kim/hs-oer-lom-profil/)
-erfolgen, welches alle notwendigen Informationen enthält.
+Die weitere Entwicklung und Pflege des Standards erfolgt in einem
+[GitHub-Repositorium](https://github.com/dini-ag-kim/hs-oer-lom-profil/),
+welches alle notwendigen Informationen enthält.
 
 <p class="copyright">
 <img alt="CC-BY-SA" src="https://i.creativecommons.org/l/by-sa/4.0/80x15.png" />
@@ -799,7 +799,7 @@ Das Element benennt die Art des Lernobjekts.
     <dd>keine</dd>
     <dt>Elemente:</dt>
     <dd>
-        <a>&lt;source></a> mit dem Wert `https://w3id.org/dini-ag-kim/hcrt/scheme`<br>
+        <a>&lt;source></a> mit dem Wert `https://w3id.org/kim/hcrt/scheme`<br>
         <a>&lt;id></a><br>
         <a>&lt;entry></a> - Es benennt die konkrete Art des Objekts
         mittels eines Labels. Da die <a>&lt;id></a>
@@ -968,7 +968,7 @@ Das Element beschreibt den Pfad der Taxonomie in der konkreten Klassifizierung.
     <dt>Elemente:</dt>
     <dd>
         <a>&lt;source></a> - Je nach verwendeter Klassifizierung wird es auf den
-        Wert `https://w3id.org/class/hochschulfaechersystematik/scheme` oder `DDC` gesetzt.
+        Wert `https://w3id.org/kim/hochschulfaechersystematik/scheme` oder `DDC` gesetzt.
 
         <a>&lt;taxon></a>
     </dd>
@@ -1298,8 +1298,8 @@ kontrolliertes Vokabular zurückgegriffen.
 ## Das Element <dfn><code>&lt;source></code></dfn>
 
 Das Element benennt die Quelle des Vokabulars. Es ist abhängig vom Kontext der
-Verwendung auf `LOMv1.0`, `https://w3id.org/dini-ag-kim/hcrt/scheme`,
-`https://w3id.org/class/hochschulfaechersystematik/scheme` oder `DDC` zu
+Verwendung auf `LOMv1.0`, `https://w3id.org/dini-ag-kim/kim/scheme`,
+`https://w3id.org/kim/hochschulfaechersystematik/scheme` oder `DDC` zu
 setzen. Die zulässigen Werte sind jeweils beim übergeordneten Element angegeben.
 
 <dl>

--- a/draft/schemas/hs-oer-lom.xsd
+++ b/draft/schemas/hs-oer-lom.xsd
@@ -29,7 +29,7 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
   </xs:complexType>
   <xs:complexType name="CCCMSOURCE">
     <xs:sequence>
-      <xs:element name="langstring" type="ATTRLANGNONE" fixed="Hochschulcampus Content Custom Model"/>
+      <xs:element name="langstring" type="ATTRLANGNONE" fixed="https://w3id.org/dini-ag-kim/hcrt/scheme"/>
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="LANGSTRINGS">
@@ -170,53 +170,18 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
       <xs:element minOccurs="0" name="description" type="DESCRIPTIONS"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:simpleType name="LRTVALUELIST">
-    <xs:restriction base="xs:string">
-      <xs:enumeration value="application"/>
-      <xs:enumeration value="assessment"/>
-      <xs:enumeration value="audio"/>
-      <xs:enumeration value="case_study"/>
-      <xs:enumeration value="course"/>
-      <xs:enumeration value="data"/>
-      <xs:enumeration value="diagram"/>
-      <xs:enumeration value="drill_and_practice"/>
-      <xs:enumeration value="educational_game"/>
-      <xs:enumeration value="experiment"/>
-      <xs:enumeration value="image"/>
-      <xs:enumeration value="index"/>
-      <xs:enumeration value="lesson_plan"/>
-      <xs:enumeration value="map"/>
-      <xs:enumeration value="other"/>
-      <xs:enumeration value="portal"/>
-      <xs:enumeration value="questionnaire"/>
-      <xs:enumeration value="script"/>
-      <xs:enumeration value="simulation"/>
-      <xs:enumeration value="slide"/>
-      <xs:enumeration value="text"/>
-      <xs:enumeration value="video"/>
-      <xs:enumeration value="web_page"/>
-      <xs:enumeration value="worksheet"/>
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:complexType name="LRTVALUE">
-    <xs:simpleContent>
-      <xs:extension base="LRTVALUELIST">
-        <xs:attribute ref="xml:lang" use="required" fixed="x-none"/>
-      </xs:extension>
-    </xs:simpleContent>
-  </xs:complexType>
   <xs:complexType name="LRT">
     <xs:sequence>
       <xs:element name="source" type="CCCMSOURCE"/>
-      <xs:element name="value">
-        <xs:complexType>
-          <xs:sequence>
-            <xs:element name="langstring" type="LRTVALUE"/>
-          </xs:sequence>
-        </xs:complexType>
-      </xs:element>
+      <xs:element name="id" type="LRTIDS"/>
+      <xs:element ref="entry"/>
     </xs:sequence>
   </xs:complexType>
+  <xs:simpleType name="LRTIDS">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="https://w3id.org/dini-ag-kim/hcrt/([A-Za-z0-9_-])+"/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="RIGHTSVALUELIST">
     <xs:restriction base="xs:string">
       <xs:enumeration value="yes"/>
@@ -268,7 +233,7 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
   </xs:simpleType>
   <xs:simpleType name="HSFAECHERVALUELIST">
     <xs:restriction base="xs:string">
-      <xs:enumeration value="Hochschulfaecher"/>
+      <xs:enumeration value="https://w3id.org/class/hochschulfaechersystematik/scheme#"/>
       <xs:enumeration value="DDC"/>
     </xs:restriction>
   </xs:simpleType>

--- a/draft/schemas/hs-oer-lom.xsd
+++ b/draft/schemas/hs-oer-lom.xsd
@@ -8,7 +8,7 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
   targetNamespace="https://www.oerbw.de/hsoerlom" 
   xmlns="https://www.oerbw.de/hsoerlom">
   <xs:import namespace="http://www.w3.org/XML/1998/namespace"
-    schemaLocation="https://w3id.org/dini-ag-kim/hs-oer-lom-profil/draft/schemas/xml.xsd"/>
+    schemaLocation="xml.xsd"/>
   <xs:simpleType name="LOCISURI">
     <xs:restriction base="xs:string">
       <xs:enumeration value="URI"/>
@@ -29,7 +29,7 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
   </xs:complexType>
   <xs:complexType name="CCCMSOURCE">
     <xs:sequence>
-      <xs:element name="langstring" type="ATTRLANGNONE" fixed="https://w3id.org/dini-ag-kim/hcrt/scheme"/>
+      <xs:element name="langstring" type="ATTRLANGNONE" fixed="https://w3id.org/kim/hcrt/scheme"/>
     </xs:sequence>
   </xs:complexType>
   <xs:complexType name="LANGSTRINGS">
@@ -179,7 +179,7 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
   </xs:complexType>
   <xs:simpleType name="LRTIDS">
     <xs:restriction base="xs:string">
-      <xs:pattern value="https://w3id.org/dini-ag-kim/hcrt/([A-Za-z0-9_-])+"/>
+      <xs:pattern value="https://w3id.org/kim/hcrt/([A-Za-z0-9_-])+"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="RIGHTSVALUELIST">
@@ -228,12 +228,12 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
   </xs:complexType>
   <xs:simpleType name="IDS">
     <xs:restriction base="xs:string">
-      <xs:pattern value="http://w3id.org/class/hochschulfaechersystematik/[a-z]([0-9])+#|[0-9][0-9][0-9]"/>
+      <xs:pattern value="http://w3id.org/kim/hochschulfaechersystematik/[a-z]([0-9])+|[0-9][0-9][0-9]"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="HSFAECHERVALUELIST">
     <xs:restriction base="xs:string">
-      <xs:enumeration value="https://w3id.org/class/hochschulfaechersystematik/scheme"/>
+      <xs:enumeration value="https://w3id.org/kim/hochschulfaechersystematik/scheme"/>
       <xs:enumeration value="DDC"/>
     </xs:restriction>
   </xs:simpleType>

--- a/draft/schemas/hs-oer-lom.xsd
+++ b/draft/schemas/hs-oer-lom.xsd
@@ -233,7 +233,7 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
   </xs:simpleType>
   <xs:simpleType name="HSFAECHERVALUELIST">
     <xs:restriction base="xs:string">
-      <xs:enumeration value="https://w3id.org/class/hochschulfaechersystematik/scheme#"/>
+      <xs:enumeration value="https://w3id.org/class/hochschulfaechersystematik/scheme"/>
       <xs:enumeration value="DDC"/>
     </xs:restriction>
   </xs:simpleType>


### PR DESCRIPTION
Ich habe die Learning Resource Types entsprechend der SKOS Repräsentation angepasst.
@sebastian-meyer , ich habe mich bemüht, mich an die ReSpec-Vorgaben zu halten, dabei musste 'id' in die mehrfach vorkommenden Elemente verschoben werden, bitte nochmal kontrollieren.
Außerdem fiel mir auf, dass 'source' sowohl den Partner 'value' als auch 'id' / 'entry' haben kann. Nur noch für 1 (LOMv.1.0) der bei 'source' angeg. Werte ist der Partner 'value'. Ich wusste aber nicht, wie das regelkonform umzusetzen ist, momentan ist es aber nicht ideal. Kannst Du das mit Deiner Erfahrung noch anpassen?

Zusätzlich noch kleinere Änderungen, die hier mit drin sind (ich bemühe mich zukünftig um noch mehr Trennung):
- in der Klassifikation die 'source' geändert von 'Hochschulfaecher' in die W3ID-URL
- Auflistung der lt. LOM möglichen anderen Werte für 'role' entfernt
- Verweis jetzt auf LOM 1.2.4 statt 1.2.1, im Verzeichnis dabei Link auf die allg. Seite gesetzt, da es kein passenden speziellen Link gibt, bitte nochmal überprüfen u. ggflls. verbessern.