### PR TITLE
Mehrfachelemente nicht mehr in Anzahl beschränkt;

### DIFF
--- a/draft/examples/classification-example.xml
+++ b/draft/examples/classification-example.xml
@@ -17,18 +17,18 @@
                 <entry>
                     <langstring>Mathematik, Naturwissenschaften</langstring>
                 </entry>
-                <taxon>
-                    <id>http://w3id.org/class/hochschulfaechersystematik/n37#</id>
-                    <entry>
-                        <langstring>Studienbereich Mathematik</langstring>
-                    </entry>
-                    <taxon>
-                        <id>http://w3id.org/class/hochschulfaechersystematik/n276#</id>
-                        <entry>
-                            <langstring>Wirtschaftsmathematik</langstring>
-                        </entry>
-                    </taxon>
-                </taxon>
+            </taxon>
+            <taxon>
+                <id>http://w3id.org/class/hochschulfaechersystematik/n37#</id>
+                <entry>
+                    <langstring>Studienbereich Mathematik</langstring>
+                </entry>
+            </taxon>
+            <taxon>
+                <id>http://w3id.org/class/hochschulfaechersystematik/n276#</id>
+                <entry>
+                    <langstring>Wirtschaftsmathematik</langstring>
+                </entry>
             </taxon>
         </taxonpath>
         <taxonpath>
@@ -40,12 +40,12 @@
                 <entry>
                     <langstring>Rechts- Wirtschafts- und Sozialwissenschaften</langstring>
                 </entry>
-                <taxon>
-                    <id>http://w3id.org/class/hochschulfaechersystematik/n30#</id>
-                    <entry>
-                        <langstring>Wirtschaftswissenschaften</langstring>
-                    </entry>
-                </taxon>
+            </taxon>
+            <taxon>
+                <id>http://w3id.org/class/hochschulfaechersystematik/n30#</id>
+                <entry>
+                    <langstring>Wirtschaftswissenschaften</langstring>
+                </entry>
             </taxon>
         </taxonpath>
         <taxonpath>
@@ -57,12 +57,12 @@
                 <entry>
                     <langstring>Science</langstring>
                 </entry>
-                <taxon>
-                    <id>510</id>
-                    <entry>
-                        <langstring>Mathematics</langstring>
-                    </entry>
-                </taxon>
+            </taxon>
+            <taxon>
+                <id>510</id>
+                <entry>
+                    <langstring>Mathematics</langstring>
+                </entry>
             </taxon>
         </taxonpath>
     </classification>

--- a/draft/examples/full-example-a.xml
+++ b/draft/examples/full-example-a.xml
@@ -9,9 +9,9 @@
 				<langstring>Introduction to Difference Equations</langstring>
 			</title>
 			<catalogentry>
-				<catalog>Handle.Net</catalog>
+				<catalog>HDL</catalog>
 				<entry>
-					<langstring>http://hdl.handle.net/10900.3/OER_ZZxWvFJV</langstring>
+					<langstring>10900.3/OER_ZZxWvFJV</langstring>
 				</entry>
 			</catalogentry>
 			<language>en</language>
@@ -164,18 +164,18 @@
 					<entry>
 						<langstring>Mathematik, Naturwissenschaften</langstring>
 					</entry>
-					<taxon>
-						<id>http://w3id.org/class/hochschulfaechersystematik/n37#</id>
-						<entry>
-							<langstring>Studienbereich Mathematik</langstring>
-						</entry>
-						<taxon>
-							<id>http://w3id.org/class/hochschulfaechersystematik/n276#</id>
-							<entry>
-								<langstring>Wirtschaftsmathematik</langstring>
-							</entry>
-						</taxon>
-					</taxon>
+				</taxon>
+				<taxon>
+					<id>http://w3id.org/class/hochschulfaechersystematik/n37#</id>
+					<entry>
+						<langstring>Studienbereich Mathematik</langstring>
+					</entry>
+				</taxon>
+				<taxon>
+					<id>http://w3id.org/class/hochschulfaechersystematik/n276#</id>
+					<entry>
+						<langstring>Wirtschaftsmathematik</langstring>
+					</entry>
 				</taxon>
 			</taxonpath>
 			<taxonpath>
@@ -187,12 +187,12 @@
 					<entry>
 						<langstring> Rechts-, Wirtschafts- und Sozialwissenschaften</langstring>
 					</entry>
-					<taxon>
-						<id>http://w3id.org/class/hochschulfaechersystematik/n30#</id>
-						<entry>
-							<langstring>Wirtschaftswissenschaften</langstring>
-						</entry>
-					</taxon>
+				</taxon>
+				<taxon>
+					<id>http://w3id.org/class/hochschulfaechersystematik/n30#</id>
+					<entry>
+						<langstring>Wirtschaftswissenschaften</langstring>
+					</entry>
 				</taxon>
 			</taxonpath>
 		</classification>

--- a/draft/examples/full-example-b.xml
+++ b/draft/examples/full-example-b.xml
@@ -9,9 +9,9 @@
 				<langstring>Baustein 5 Classroom Action Research</langstring>
 			</title>
 			<catalogentry>
-				<catalog>Handle.Net</catalog>
+				<catalog>HDL</catalog>
 				<entry>
-					<langstring>http://hdl.handle.net/10900.3/OER_qiYOaTBN</langstring>
+					<langstring>10900.3/OER_qiYOaTBN</langstring>
 				</entry>
 			</catalogentry>
 			<language>de</language>
@@ -209,18 +209,18 @@
 					<entry>
 						<langstring> Rechts-, Wirtschafts- und Sozialwissenschaften</langstring>
 					</entry>
-					<taxon>
-						<id>http://w3id.org/class/hochschulfaechersystematik/n33#</id>
-						<entry>
-							<langstring>Erziehungswissenschaften</langstring>
-						</entry>
-						<taxon>
-							<id>http://w3id.org/class/hochschulfaechersystematik/n052#</id>
-							<entry>
-								<langstring>Erziehungswissenschaft (Pädagogik)</langstring>
-							</entry>
-						</taxon>
-					</taxon>
+				</taxon>
+				<taxon>
+					<id>http://w3id.org/class/hochschulfaechersystematik/n33#</id>
+					<entry>
+						<langstring>Erziehungswissenschaften</langstring>
+					</entry>
+				</taxon>
+				<taxon>
+					<id>http://w3id.org/class/hochschulfaechersystematik/n052#</id>
+					<entry>
+						<langstring>Erziehungswissenschaft (Pädagogik)</langstring>
+					</entry>
 				</taxon>
 			</taxonpath>
 			<taxonpath>
@@ -232,18 +232,18 @@
 					<entry>
 						<langstring>Social sciences</langstring>
 					</entry>
-					<taxon>
-						<id>370</id>
-						<entry>
-							<langstring>Education</langstring>
-						</entry>
-						<taxon>
-							<id>378</id>
-							<entry>
-								<langstring>Higher education</langstring>
-							</entry>
-						</taxon>
-					</taxon>
+				</taxon>
+				<taxon>
+					<id>370</id>
+					<entry>
+						<langstring>Education</langstring>
+					</entry>
+				</taxon>
+				<taxon>
+					<id>378</id>
+					<entry>
+						<langstring>Higher education</langstring>
+					</entry>
 				</taxon>
 			</taxonpath>
 		</classification>

--- a/draft/examples/general-example.xml
+++ b/draft/examples/general-example.xml
@@ -5,9 +5,9 @@
             <langstring>Baustein 5 Classroom Action Research</langstring>
         </title>
         <catalogentry>
-            <catalog>Handle.Net</catalog>
+            <catalog>HDL</catalog>
             <entry>
-                <langstring>http://hdl.handle.net/10900.3/OER_qiYOaTBN</langstring>
+                <langstring>10900.3/OER_qiYOaTBN</langstring>
             </entry>
         </catalogentry>
         <language>de</language>

--- a/draft/index.html
+++ b/draft/index.html
@@ -369,11 +369,11 @@ Das Element benennt den Katalog, d.h. das Identifizierungssystem.
     <dd>keine</dd>
     <dd>Die erlaubten Werte sind:
 
-        - `DOI` - für Digital Object Identifiers [[?ISO26324]]
+- `DOI` - für Digital Object Identifiers [[!ISO26324]]
 
-        - `HDL` - für Handles [[!RFC3650]]
+- `HDL` - für Handles [[!RFC3650]]
 
-        - `URN` - für Uniform Resource Names [[!RFC8141]]
+- `URN` - für Uniform Resource Names [[!RFC8141]]
 </dl>
 
 </section>

--- a/draft/index.html
+++ b/draft/index.html
@@ -79,6 +79,12 @@
                     href: "https://edu-sharing.com/",
                     publisher: "metaVentis GmbH"
                 },
+                "ISO26324": {
+                    title: "Information and documentation — Digital object identifier system. ISO 26324:2012",
+                    href: "https://www.iso.org/standard/43506.html",
+                    status: "Last Reviewed and confirmed in 2017",
+                    publisher: "International Organization for Standardization (ISO)"
+                },
                 "LOMv1.0": {
                     title: "IEEE Standard for Learning Object Metadata",
                     href: "https://ieeexplore.ieee.org/document/1032843/",
@@ -356,6 +362,13 @@ Das Element benennt den Katalog, d.h. das Identifizierungssystem.
     <dd>keine</dd>
     <dt>Elemente:</dt>
     <dd>keine</dd>
+    <dd>Die erlaubten Werte sind:
+
+        - `DOI` - für Digital Object Identifiers [[?ISO26324]]
+
+        - `HDL` - für Handles [[!RFC3650]]
+
+        - `URN` - für Uniform Resource Names [[!RFC8141]]
 </dl>
 
 </section>
@@ -646,7 +659,7 @@ oder `image/png`.
     <dt>Mehrwertigkeit:</dt>
     <dd>
         Es DARF nicht oder ein- oder mehrfach innerhalb des Elements
-        <a>&lt;technical></a> vorkommen, maximal jedoch 10 Mal. Es ist möglich, dass
+        <a>&lt;technical></a> vorkommen. Es ist möglich, dass
         das Lernobjekt in verschiedenen Formaten angeboten wird.
     </dd>
     <dt>Attribute:</dt>
@@ -787,7 +800,7 @@ Das Element benennt die Art des Lernobjekts.
     <dt>Mehrwertigkeit:</dt>
     <dd>
         Es DARF nicht oder ein- oder mehrfach innerhalb des Elements
-        <a>&lt;educational></a> vorkommen, maximal jedoch 10 Mal.
+        <a>&lt;educational></a> vorkommen.
     </dd>
     <dt>Attribute:</dt>
     <dd>keine</dd>
@@ -1017,7 +1030,7 @@ Das Element beschreibt den Pfad der Taxonomie in der konkreten Klassifizierung.
     <dt>Mehrwertigkeit:</dt>
     <dd>
         Es MUSS ein- oder mehrfach innerhalb des Elements <a>&lt;classification></a>
-        vorkommen, maximal jedoch 10 Mal.
+        vorkommen.
     </dd>
     <dt>Attribute:</dt>
     <dd>keine</dd>
@@ -1036,15 +1049,15 @@ Das Element beschreibt den Pfad der Taxonomie in der konkreten Klassifizierung.
 
 Das Element beschreibt einen Eintrag in der Klassifikation.
 
-<code>&lt;taxon></code>-Elemente können ineinander geschachtelt werden und bilden
-damit einen Taxonomiepfad, d. h. eine hierarchisch sich verfeinernde Klassifikation.
+<code>&lt;taxon></code>-Elemente werden als Liste repräsentiert und bilden
+damit einen Taxonomiepfad, d. h. eine hierarchisch sich verfeinernde
+Klassifikation.
 
 <dl>
     <dt>Mehrwertigkeit:</dt>
     <dd>
-        Es MUSS genau 1 Mal innerhalb des Elements <a>&lt;taxonpath></a> vorkommen.
-
-        Es DARF 1 Mal innerhalb des Elements <a>&lt;taxon></a> vorkommen.
+         Es MUSS ein- oder mehrfach innerhalb des Elements <a>&lt;taxonpath></a>
+    vorkommen.
     </dd>
     <dt>Attribute:</dt>
     <dd>keine</dd>
@@ -1055,7 +1068,6 @@ damit einen Taxonomiepfad, d. h. eine hierarchisch sich verfeinernde Klassifikat
         Rahmen der bezeichneten Taxonomie mittels eines Labels. Da die <a>&lt;id></a>
         das entscheidende Klassifikationsmerkmal ist, hat dieses Element nur
         beschreibenden Charakter.<br>
-        <a>&lt;taxon></a>
     </dd>
 </dl>
 
@@ -1260,8 +1272,8 @@ Das Element beschreibt die Art der Beteiligung.
 
 ## Das Element <dfn><code>&lt;centity></code></dfn>
 
-Das Element enthält die Informationen über die Beteiligten in der angeführten Rolle,
-bedeutendste Beteiligte zuerst.
+Das Element enthält die Informationen über die Beteiligten in der angeführten
+Rolle, bedeutendste Beteiligte zuerst.
 
 <dl>
     <dt>Mehrwertigkeit:</dt>

--- a/draft/schemas/hs-oer-lom.xsd
+++ b/draft/schemas/hs-oer-lom.xsd
@@ -44,6 +44,13 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
       <xs:element name="langstring" type="LANGSTRINGS"/>
     </xs:sequence>
   </xs:complexType>
+  <xs:simpleType name="CATALOGS">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="DOI"/>
+      <xs:enumeration value="HDL"/>
+      <xs:enumeration value="URN"/>
+    </xs:restriction>
+  </xs:simpleType>
   <xs:simpleType name="AGGREGATLEVELVALUELIST">
     <xs:restriction base="xs:positiveInteger">
       <xs:maxInclusive value="4"/>
@@ -258,7 +265,6 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
     <xs:sequence>
       <xs:element name="id" type="IDS"/>
       <xs:element ref="entry"/>
-      <xs:element minOccurs="0" name="taxon" type="TAXONS"/>
     </xs:sequence>
   </xs:complexType>
   <xs:simpleType name="IDS">
@@ -288,7 +294,7 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="taxon" type="TAXONS"/>
+      <xs:element maxOccurs="unbounded" name="taxon" type="TAXONS"/>
     </xs:sequence>
   </xs:complexType>
   <xs:element name="entry">
@@ -347,7 +353,7 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  <xs:element name="catalog" type="xs:NCName"/>
+  <xs:element name="catalog" type="CATALOGS"/>
   <xs:element name="language">
     <xs:simpleType>
       <xs:restriction base="xs:string">
@@ -415,7 +421,7 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
   <xs:element name="technical">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="10" name="format" type="xs:string"/>
+        <xs:element maxOccurs="unbounded" name="format" type="xs:string"/>
         <xs:element minOccurs="0" name="size" type="xs:positiveInteger"/>
         <xs:element minOccurs="0" ref="location"/>
         <xs:element minOccurs="0" name="otherplatformrequirements" type="xs:string"/>
@@ -435,7 +441,7 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
   <xs:element name="educational">
     <xs:complexType>
       <xs:sequence>
-        <xs:element maxOccurs="10" name="learningResourceType" type="LRT"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" name="learningResourceType" type="LRT"/>
         <xs:element minOccurs="0" name="description" type="DESCRIPTIONS"/>
       </xs:sequence>
     </xs:complexType>
@@ -453,7 +459,7 @@ https://w3id.org/dini-ag-kim/hs-oer-lom-profil/ -->
     <xs:complexType>
       <xs:sequence>
         <xs:element name="purpose" type="FACHCLASSPURPOSE"/>
-        <xs:element maxOccurs="10" name="taxonpath" type="HSFAECHER"/>
+        <xs:element maxOccurs="unbounded" name="taxonpath" type="HSFAECHER"/>
       </xs:sequence>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
#8 : Mehrfachelemente nicht mehr in Anzahl beschränkt;
Taxons als Liste statt als Hierarchie;
Werte in \<catalog\> beschränkt auf festes Vokabular - @sebastian-meyer kannst Du bitte nochmal schauen, ich habe es nicht geschafft, die ISO 26324 Norm für DOIs als erkannten Standard zu referenzieren.