### PR TITLE
Fix Wikidata URIs

### DIFF
--- a/draft/examples/full-example-a.xml
+++ b/draft/examples/full-example-a.xml
@@ -97,7 +97,7 @@
 						BEGIN:VCARD
 						VERSION:3.0
 						ORG:Universität Tübingen
-						URL:https://www.wikidata.org/wiki/Q153978
+						URL:https://www.wikidata.org/entity/Q153978
 						END:VCARD
 					</vcard>
 				</centity>

--- a/draft/examples/full-example-b.xml
+++ b/draft/examples/full-example-b.xml
@@ -151,7 +151,7 @@
 						BEGIN:VCARD
 						VERSION:3.0
 						ORG:PH Freiburg
-						URL:https://www.wikidata.org/wiki/Q1441203
+						URL:https://www.wikidata.org/entity/Q1441203
 						END:VCARD
 					</vcard>
 				</centity>

--- a/draft/examples/metametadata-example.xml
+++ b/draft/examples/metametadata-example.xml
@@ -40,7 +40,7 @@
                     BEGIN:VCARD
                     VERSION:3.0
                     ORG:Universität Tübingen
-                    URL:https://www.wikidata.org/wiki/Q153978
+                    URL:https://www.wikidata.org/entity/Q153978
                     END:VCARD
                 </vcard>
             </centity>


### PR DESCRIPTION
...because the URI for the thing itself, e.g. the university, differs
from the URI about the Wikidata page. The first starts with
`https://www.wikidata.org/entity/`, the second with
`https://www.wikidata.org/wiki/`.