### PR TITLE
Allow to specify more than 1 language for an object.

### DIFF
--- a/draft/examples/full-example-a.xml
+++ b/draft/examples/full-example-a.xml
@@ -20,6 +20,7 @@
 					<langstring>10900.3/OER_ZZxWvFJV</langstring>
 				</entry>
 			</catalogentry>
+			<language>de</language>
 			<language>en</language>
 			<description>
 				<langstring>Vorbereitung auf einen Kurs zur Zeitreihenanalyse</langstring>

--- a/draft/index.html
+++ b/draft/index.html
@@ -395,10 +395,12 @@ Das Element benennt die Sprache des Inhalts des Lernobjekts.
 Der Wert besteht aus einem zweibuchstabigem Kürzel für die Sprache, z. B. `de`,
 nach [[!ISO-639-1]]. Kompliziertere Varianten mit Subtags, z.B. `en-US`, werden bis
 auf weiteres nicht unterstützt.
+Kann keine Sprache, z. B. bei Bildern, angegeben werden, DARF der Wert `xnone`
+gesetzt werden.
 
 <dl>
     <dt>Mehrwertigkeit:</dt>
-    <dd>Es DARF 1 Mal innerhalb des Elements <a>&lt;general></a> vorkommen.</dd>
+    <dd>Es DARF ein- oder mehrfach innerhalb des Elements <a>&lt;general></a> vorkommen.</dd>
     <dt>Attribute:</dt>
     <dd>keine</dd>
     <dt>Elemente:</dt>

--- a/draft/index.html
+++ b/draft/index.html
@@ -390,9 +390,9 @@ Die erlaubten Werte sind:
 
 ## Das Element <dfn><code>&lt;language></code></dfn>
 
-Das Element benennt die Sprache des Inhalts des Lernobjekts.
+Das Element benennt die Sprache(n) des Inhalts des Lernobjekts.
 
-Der Wert besteht aus einem zweibuchstabigem Kürzel für die Sprache, z. B. `de`,
+Werte bestehen aus einem zweibuchstabigem Kürzel für die Sprache, z. B. `de`,
 nach [[!ISO-639-1]]. Kompliziertere Varianten mit Subtags, z.B. `en-US`, werden bis
 auf weiteres nicht unterstützt.
 Kann keine Sprache, z. B. bei Bildern, angegeben werden, DARF der Wert `xnone`

--- a/draft/schemas/hs-oer-lom.xsd
+++ b/draft/schemas/hs-oer-lom.xsd
@@ -295,7 +295,7 @@ https://w3id.org/dini/hs-oer-lom-profil/ -->
         <xs:element ref="identifier"/>
         <xs:element maxOccurs="unbounded" ref="title"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="catalogentry"/>
-        <xs:element minOccurs="0" ref="language"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="language"/>
         <xs:element minOccurs="0" name="description" type="DESCRIPTIONS"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="keyword"/>
         <xs:element minOccurs="0" name="aggregationlevel" type="AGGREGATLEVEL"/>


### PR DESCRIPTION
Eine OER darf in mehreren Sprachen vorliegen, z.B. bei Übersetzungen.