### PR TITLE
Identifier

### DIFF
--- a/draft/examples/full-example-a.xml
+++ b/draft/examples/full-example-a.xml
@@ -4,7 +4,7 @@
 	xsi:schemaLocation="https://www.oerbw.de/hsoerlom https://w3id.org/kim/hs-oer-lom-profil/draft/schemas/hs-oer-lom.xsd">
 	<lom>
 		<general>
-		  	<identifier>
+			<identifier>
 				<catalog>ZOERR</catalog>
 				<entry>
 					<langstring>c0a478bd-b5f0-4d67-89c5-4a49dfefddcf</langstring>

--- a/draft/examples/full-example-a.xml
+++ b/draft/examples/full-example-a.xml
@@ -4,22 +4,27 @@
 	xsi:schemaLocation="https://www.oerbw.de/hsoerlom https://w3id.org/kim/hs-oer-lom-profil/draft/schemas/hs-oer-lom.xsd">
 	<lom>
 		<general>
-			<identifier>c0a478bd-b5f0-4d67-89c5-4a49dfefddcf</identifier>
-			<title>
-				<langstring>Introduction to Difference Equations</langstring>
-			</title>
-			<catalogentry>
+		  	<identifier>
+				<catalog>ZOERR</catalog>
+				<entry>
+					<langstring>c0a478bd-b5f0-4d67-89c5-4a49dfefddcf</langstring>
+				</entry>
+			</identifier>
+			<identifier>
 				<catalog>DOI</catalog>
 				<entry>
 					<langstring>10.1137/S0036144500378302</langstring>
 				</entry>
-			</catalogentry>
-			<catalogentry>
+			</identifier>
+			<identifier>
 				<catalog>HDL</catalog>
 				<entry>
 					<langstring>10900.3/OER_ZZxWvFJV</langstring>
 				</entry>
-			</catalogentry>
+			</identifier>
+			<title>
+				<langstring>Introduction to Difference Equations</langstring>
+			</title>
 			<language>en</language>
 			<description>
 				<langstring>Vorbereitung auf einen Kurs zur Zeitreihenanalyse</langstring>

--- a/draft/examples/full-example-b.xml
+++ b/draft/examples/full-example-b.xml
@@ -4,16 +4,21 @@
 	xsi:schemaLocation="https://www.oerbw.de/hsoerlom https://w3id.org/kim/hs-oer-lom-profil/draft/schemas/hs-oer-lom.xsd">
 	<lom>
 		<general>
-			<identifier>8dee40f6-0b22-4e5c-9d39-7ebeb7d20b9f</identifier>
-			<title>
-				<langstring>Baustein 5 Classroom Action Research</langstring>
-			</title>
-			<catalogentry>
+			<identifier>
+				<catalog>Ein OER Repositorium</catalog>
+				<entry>
+					<langstring>8dee40f6-0b22-4e5c-9d39-7ebeb7d20b9f</langstring>
+				</entry>
+			</identifier>
+			<identifier>
 				<catalog>HDL</catalog>
 				<entry>
 					<langstring>10900.3/OER_qiYOaTBN</langstring>
 				</entry>
-			</catalogentry>
+			</identifier>
+			<title>
+				<langstring>Baustein 5 Classroom Action Research</langstring>
+			</title>
 			<language>de</language>
 			<description>
 				<langstring>Studierende führen im Rahmen von Praxisphasen Klassenforschungsprojekte durch.</langstring>

--- a/draft/examples/general-example.xml
+++ b/draft/examples/general-example.xml
@@ -4,8 +4,8 @@
             <catalog>OER Sammlung</catalog>
             <entry>
                 <langstring>8dee40f6-0b22-4e5c-9d39-7ebeb7d20b9f</langstring>
-	    </entry>
-	</identifier>
+            </entry>
+        </identifier>
         <identifier>
             <catalog>HDL</catalog>
             <entry>

--- a/draft/examples/general-example.xml
+++ b/draft/examples/general-example.xml
@@ -1,15 +1,20 @@
 <lom>
     <general>
-        <identifier>8dee40f6-0b22-4e5c-9d39-7ebeb7d20b9f</identifier>
-        <title>
-            <langstring>Baustein 5 Classroom Action Research</langstring>
-        </title>
-        <catalogentry>
+        <identifier>
+            <catalog>OER Sammlung</catalog>
+            <entry>
+                <langstring>8dee40f6-0b22-4e5c-9d39-7ebeb7d20b9f</langstring>
+	    </entry>
+	</identifier>
+        <identifier>
             <catalog>HDL</catalog>
             <entry>
                 <langstring>10900.3/OER_qiYOaTBN</langstring>
             </entry>
-        </catalogentry>
+        </identifier>
+        <title>
+            <langstring>Baustein 5 Classroom Action Research</langstring>
+        </title>
         <language>de</language>
         <description>
             <langstring>

--- a/draft/index.html
+++ b/draft/index.html
@@ -328,13 +328,13 @@ Das Element benennt den Katalog, d.h. das Identifizierungssystem.
 
 <dl>
     <dt>Mehrwertigkeit:</dt>
-    <dd>Es MUSS genau 1 Mal innerhalb des Elements <a>&lt;catalogentry></a> vorkommen.</dd>
+    <dd>Es MUSS genau 1 Mal innerhalb des Elements <a>&lt;identifier></a> vorkommen.</dd>
     <dt>Attribute:</dt>
     <dd>keine</dd>
     <dt>Elemente:</dt>
     <dd>keine</dd>
     <dd>
-Erlaubten Werte sind vom Typ `String`, die keiner Einschränkung unterliegen. Es
+Erlaubte Werte sind vom Typ `String`, die keiner Einschränkung unterliegen. Es
     werden aber folgende Bezeichner für Standards reserviert:
 
 - `DOI` - für Digital Object Identifiers [[!ISO26324]]

--- a/draft/index.html
+++ b/draft/index.html
@@ -288,7 +288,6 @@ Das Element beschreibt das Lernobjekt allgemein.
     <dd>
         <a>&lt;identifier></a><br>
         <a>&lt;title></a><br>
-        <a>&lt;catalogentry></a><br>
         <a>&lt;language></a><br>
         <a>&lt;description></a><br>
         <a>&lt;keyword></a><br>
@@ -304,44 +303,6 @@ Das Element beschreibt das Lernobjekt allgemein.
 
 ## Das Element <dfn><code>&lt;identifier></code></dfn>
 
-Das Element bezeichnet eine innerhalb des Repositoriums eindeutige Identifizierung.
-Es hat Werte vom Typ `String`, die keiner Einschränkung unterliegen.
-
-Bei Anfragen an den OAI-Server eines Repositoriums ist der Wert dieses Elements das
-bestimmende Identifikationsmerkmal für ein Lernobjekt.
-
-<dl>
-    <dt>Mehrwertigkeit:</dt>
-    <dd>Es MUSS genau 1 Mal innerhalb des Elements <a>&lt;general></a> vorkommen.</dd>
-    <dt>Attribute:</dt>
-    <dd>keine</dd>
-    <dt>Elemente:</dt>
-    <dd>keine</dd>
-</dl>
-
-</section>
-
-<section data-dfn-for="title">
-
-## Das Element <dfn><code>&lt;title></code></dfn>
-
-Das Element gibt den Namen oder Titel des Lernobjekts an.
-
-<dl>
-    <dt>Mehrwertigkeit:</dt>
-    <dd>Es MUSS ein- oder mehrfach innerhalb des Elements <a>&lt;general></a> vorkommen.</dd>
-    <dt>Attribute:</dt>
-    <dd>keine</dd>
-    <dt>Elemente:</dt>
-    <dd><a>&lt;langstring></a></dd>
-</dl>
-
-</section>
-
-<section data-dfn-for="catalogentry">
-
-## Das Element <dfn><code>&lt;catalogentry></code></dfn>
-
 Das Element bezeichnet einen Eintrag in einem Katalog, d. h. einem
 Identifizierungssystem, der dem Objekt zugeordnet ist. Durch den Eintrag soll das
 Objekt von dritter Seite gesucht und gefunden werden können.
@@ -354,7 +315,8 @@ Objekt von dritter Seite gesucht und gefunden werden können.
     <dt>Elemente:</dt>
     <dd>
 <a>&lt;catalog></a><br>
-<a>&lt;entry></a> - Es bezeichnet den Eintrag des Objekts (ID) im Katalog, d. h. Identifizierungssystem.
+<a>&lt;entry></a> - Es bezeichnet den Eintrag des Objekts (ID) im Katalog,
+    d. h. Identifizierungssystem.
     </dd>
 </dl>
 
@@ -372,17 +334,37 @@ Das Element benennt den Katalog, d.h. das Identifizierungssystem.
     <dt>Elemente:</dt>
     <dd>keine</dd>
     <dd>
-Die erlaubten Werte sind:
+Erlaubten Werte sind vom Typ `String`, die keiner Einschränkung unterliegen. Es
+    werden aber folgende Bezeichner für Standards reserviert:
 
 - `DOI` - für Digital Object Identifiers [[!ISO26324]]
 
 - `HDL` - für Handles [[!RFC3650]]
+
+- `ISBN` - für Internationale Standardbuchnummern      
 
 - `URN` - für Uniform Resource Names [[!RFC8141]]
     </dd>
 </dl>
 
 </section>
+
+</section>
+
+<section data-dfn-for="title">
+
+## Das Element <dfn><code>&lt;title></code></dfn>
+
+Das Element gibt den Namen oder Titel des Lernobjekts an.
+
+<dl>
+    <dt>Mehrwertigkeit:</dt>
+    <dd>Es MUSS ein- oder mehrfach innerhalb des Elements <a>&lt;general></a> vorkommen.</dd>
+    <dt>Attribute:</dt>
+    <dd>keine</dd>
+    <dt>Elemente:</dt>
+    <dd><a>&lt;langstring></a></dd>
+</dl>
 
 </section>
 

--- a/draft/index.html
+++ b/draft/index.html
@@ -1100,8 +1100,7 @@ Das Element bezeichnet den konkreten Eintrag in einer Taxonomie oder einem Katal
 <dl>
     <dt>Mehrwertigkeit:</dt>
     <dd>
-Es DARF genau 1 Mal innerhalb des übergeordneten Elements vorkommen. Im Falle des
-<a>&lt;catalogentry></a> MUSS es genau 1 Mal vorkommen.
+Es DARF genau 1 Mal innerhalb des übergeordneten Elements vorkommen.
     </dd>
     <dt>Attribute:</dt>
     <dd>keine</dd>

--- a/draft/schemas/hs-oer-lom.xsd
+++ b/draft/schemas/hs-oer-lom.xsd
@@ -45,11 +45,18 @@ https://w3id.org/dini/hs-oer-lom-profil/ -->
     </xs:sequence>
   </xs:complexType>
   <xs:simpleType name="CATALOGS">
+    <xs:union memberTypes="STDCATS ANYCATS"/>
+  </xs:simpleType>
+  <xs:simpleType name="STDCATS">
     <xs:restriction base="xs:string">
       <xs:enumeration value="DOI"/>
       <xs:enumeration value="HDL"/>
+      <xs:enumeration value="ISBN"/>
       <xs:enumeration value="URN"/>
     </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ANYCATS">
+    <xs:restriction base="xs:string"/>
   </xs:simpleType>
   <xs:simpleType name="AGGREGATLEVELVALUELIST">
     <xs:restriction base="xs:positiveInteger">
@@ -292,9 +299,8 @@ https://w3id.org/dini/hs-oer-lom-profil/ -->
   <xs:element name="general">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="identifier"/>
+        <xs:element minOccurs="0" maxOccurs="unbounded" ref="identifier"/>
         <xs:element maxOccurs="unbounded" ref="title"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="catalogentry"/>
         <xs:element minOccurs="0" ref="language"/>
         <xs:element minOccurs="0" name="description" type="DESCRIPTIONS"/>
         <xs:element minOccurs="0" maxOccurs="unbounded" ref="keyword"/>
@@ -302,7 +308,6 @@ https://w3id.org/dini/hs-oer-lom-profil/ -->
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  <xs:element name="identifier" type="xs:string"/>
   <xs:element name="title">
     <xs:complexType>
       <xs:sequence>
@@ -310,7 +315,7 @@ https://w3id.org/dini/hs-oer-lom-profil/ -->
       </xs:sequence>
     </xs:complexType>
   </xs:element>
-  <xs:element name="catalogentry">
+  <xs:element name="identifier">
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="catalog"/>


### PR DESCRIPTION
Änderung des _identify_ - Elements, so dass es LOM konform ist. Dabei Entfernung von _catalogentry_. Die ursprüngliche Version kam aus der IMS LRM Spec., vgl. auch [hier](https://web.archive.org/web/20060312160932/http://www.intrallect.com/support/metadata/ims2lom_metadata_mapping.htm).
Der Mehrwert ist aber so gering, dass die LOM Konformität wichtiger ist.